### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "networkmanagement",
     "name_pretty": "Network Management API",
     "product_documentation": "https://cloud.google.com/network-management",
-    "client_documentation": "https://googleapis.dev/python/networkmanagement/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/networkmanagement/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Network Management API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-network-management.svg
    :target: https://pypi.org/project/google-cloud-network-management/
 .. _Network Management API: https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/reference/networkmanagement/rest
-.. _Client Library Documentation: https://googleapis.dev/python/networkmanagement/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/networkmanagement/latest
 .. _Product Documentation:  https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/reference/networkmanagement/rest
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.