### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-### [1.3.2](https://github.com/googleapis/python-network-management/compare/v1.3.1...v1.3.2) (2022-05-05)
+## [1.3.2](https://github.com/googleapis/python-network-management/compare/v1.3.1...v1.3.2) (2022-05-05)
 
 
 ### Documentation
 
 * fix type in docstring for map fields ([3c71bcc](https://github.com/googleapis/python-network-management/commit/3c71bcc656d1d8a1a916caf4cf0854db48eb460f))
 
-### [1.3.1](https://github.com/googleapis/python-network-management/compare/v1.3.0...v1.3.1) (2022-03-05)
+## [1.3.1](https://github.com/googleapis/python-network-management/compare/v1.3.0...v1.3.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -31,7 +31,7 @@
 
 * add generated snippets ([#68](https://github.com/googleapis/python-network-management/issues/68)) ([190d825](https://github.com/googleapis/python-network-management/commit/190d8257841cb4d2417733f8bba795ff11e635bd))
 
-### [1.2.1](https://www.github.com/googleapis/python-network-management/compare/v1.2.0...v1.2.1) (2021-11-01)
+## [1.2.1](https://www.github.com/googleapis/python-network-management/compare/v1.2.0...v1.2.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -58,14 +58,14 @@
 
 * add context manager support in client ([#38](https://www.github.com/googleapis/python-network-management/issues/38)) ([376873d](https://www.github.com/googleapis/python-network-management/commit/376873d0550999ebf9831509ce77b7b86a689059))
 
-### [1.0.2](https://www.github.com/googleapis/python-network-management/compare/v1.0.1...v1.0.2) (2021-09-30)
+## [1.0.2](https://www.github.com/googleapis/python-network-management/compare/v1.0.1...v1.0.2) (2021-09-30)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([fb7e7fd](https://www.github.com/googleapis/python-network-management/commit/fb7e7fd9915d0ee99a4741896bd2a43a57aaba77))
 
-### [1.0.1](https://www.github.com/googleapis/python-network-management/compare/v1.0.0...v1.0.1) (2021-09-24)
+## [1.0.1](https://www.github.com/googleapis/python-network-management/compare/v1.0.0...v1.0.1) (2021-09-24)
 
 
 ### Bug Fixes
@@ -79,7 +79,7 @@
 
 * bump release level to production/stable ([#16](https://www.github.com/googleapis/python-network-management/issues/16)) ([4c156cf](https://www.github.com/googleapis/python-network-management/commit/4c156cff255b33fe89637d7106a61ea9113cac26))
 
-### [0.1.1](https://www.github.com/googleapis/python-network-management/compare/v0.1.0...v0.1.1) (2021-07-26)
+## [0.1.1](https://www.github.com/googleapis/python-network-management/compare/v0.1.0...v0.1.1) (2021-07-26)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.